### PR TITLE
Respect emacsd config

### DIFF
--- a/epackage.el
+++ b/epackage.el
@@ -2193,7 +2193,7 @@ The %s marks the package name.")
 (defcustom epackage--root-directory
   (let ((dir (if (featurep 'xemacs)
                  "~/.xemacs.d"
-               "~/.emacs.d")))
+               user-emacs-directory)))
     (cond
      ((file-directory-p dir)
       dir)


### PR DESCRIPTION
While redoing my .emacs, I decided to experiment with DELPS. For the rewrite, I made a template repo to experiment with new configs without disturbing my existing one:

https://github.com/dradetsky/emacs-init-testbed

When I attempted to install epackages from within this config, the packages, they were installed under `~/.emacs.d` instead of `~/code/elisp/wherever`. We fix this by setting the default base to the value of `user-emacs-directory`.

Note that I only attempt this fix for gnu emacs, not xemacs. It may work for both, but I have no idea if the var `user-emacs-directory` exists in xemacs. I'm on arch linux, and the package manager no longer carries xemacs, probably because the last stable release was like 10 years ago or something. Feel free to look into that one yourself.